### PR TITLE
Rename extension to sourcegraph/sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/sourcegraph/sourcegraph/master/shared/src/schema/extension.schema.json",
-  "name": "sourcegraph-sentry",
+  "name": "sentry",
   "description": "Sourcegraph Sentry extension renders \"View logs on Sentry\" links next to error handling code.",
   "publisher": "Sourcegraph",
   "activationEvents": [


### PR DESCRIPTION
The extension name sourcegraph/sourcegraph-sentry is repetitive. This renames it to just sourcegraph/sentry. (The repository name is unchanged; only the extension name on Sourcegraph is changed.)